### PR TITLE
DM inline mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea/
 data/
 bin/
-.env
+.env*
 node_modules/
 yarn-error*
 .serverless/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
-# TODO:
+## TODO:
 
-- [ ] добавить `update` команду `/update@bot_name #location info` 
-  которая будет сохранять сообщения аналогично текущей логике по тегам
 - [x] починить VPC в serverless
 - [x] CI в github (+ добавить секреты)
+- [ ] В личке добавить inline кнопки Newer/Older для того чтобы получать более новые/старые сообщения по выбранной локации  
+  - [x] сделать чтобы кнопка Newer отображалась только когда есть более новые сообщения
+  - [x] сделать чтобы кнопка Older отображалась только когда есть более старые сообщения
+  - [ ] не отправлять каждый раз новое сообщение, а обновлять существующее
+- [ ] сделать inline режим для бота, чтобы `@bot Ber` подсказывал результаты
 - [ ] добавить нормальное описание (что делает бот, какие есть команды, примеры)
   - синтаксис команд для лички и для группы 
 - [ ] бонус: если `/start` команада вызвана из канала - выводить подробное описание 1 раз
+
+## How to run locally
+
+```shell
+scripts/run_with_env.sh .env-local go run main.go
+```
+
+where `.env-local` is the file with the following env variables:
+
+```
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=<db user name>
+DB_PASSWORD=<db password>
+DB_NAME=volunteers_bot
+GROUP_CHAT_ID=<main group chat ID in telegram>
+BOT_TOKEN=<bot token>
+BOT_NAME=<bot name>
+```

--- a/adapters/httpbot/client.go
+++ b/adapters/httpbot/client.go
@@ -11,42 +11,22 @@ import (
 	"strconv"
 )
 
-var (
-	startCommandText = `
-Greetings from volunteers_ua bot.
-
-Available commands:
-- /start, /help: show this message
-- /info <Location>: show messages from volunteers about <Location>, i.e. /info Berlin
-`
-	startCommandEntities = []sendMessageEntity{
-		{
-			Type:   "bold",
-			Offset: 16,
-			Length: 13,
-		},
-		{
-			Type:   "code",
-			Offset: 92,
-			Length: 16,
-		},
-		{
-			Type:   "bot_command",
-			Offset: 192,
-			Length: 12,
-		},
-	}
-
-	invalidInfoCommandText = `
-Invalid info command, maybe location is missing. Example: /info Berlin
-`
-)
-
 type sendMessagePayload struct {
-	ChatID    int64               `json:"chat_id"`
-	Text      string              `json:"text"`
-	Entities  []sendMessageEntity `json:"entities,omitempty"`
-	ParseMode string              `json:"parse_mode,omitempty"`
+	ChatID      int64               `json:"chat_id"`
+	Text        string              `json:"text"`
+	Entities    []sendMessageEntity `json:"entities,omitempty"`
+	ReplyMarkup replyMarkup         `json:"reply_markup,omitempty"`
+	ParseMode   string              `json:"parse_mode,omitempty"`
+}
+
+type replyMarkup struct {
+	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard,omitempty"`
+}
+
+type InlineKeyboardButton struct {
+	Text                         string `json:"text"`
+	CallbackData                 string `json:"callback_data"`
+	SwitchInlineQueryCurrentChat string `json:"switch_inline_query_current_chat"`
 }
 
 type sendMessageEntity struct {
@@ -58,45 +38,16 @@ type sendMessageEntity struct {
 type Client struct {
 }
 
-func (c *Client) SendWelcomeMessage(botToken string, receiverID int64) error {
-	log.Println("SendWelcomeMessage is called")
+func (c *Client) SendMessage(botToken string, receiverID int64, message string, inlineButtons [][]InlineKeyboardButton) error {
+	log.Println("SendMessage is called")
 	payload := sendMessagePayload{
-		ChatID:   receiverID,
-		Text:     startCommandText,
-		Entities: startCommandEntities,
+		ChatID:      receiverID,
+		Text:        message,
+		ReplyMarkup: replyMarkup{InlineKeyboard: inlineButtons},
 	}
 	data, err := json.Marshal(payload)
 
-	if err != nil {
-		return err
-	}
-	u := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", botToken)
-	return c.sendMessage(data, u)
-}
-
-func (c *Client) SendInvalidInfoCommandMessage(botToken string, receiverID int64) error {
-	log.Println("SendInvalidInfoCommandMessage is called")
-	payload := sendMessagePayload{
-		ChatID:   receiverID,
-		Text:     invalidInfoCommandText,
-		Entities: nil,
-	}
-	data, err := json.Marshal(payload)
-
-	if err != nil {
-		return err
-	}
-	u := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", botToken)
-	return c.sendMessage(data, u)
-}
-
-func (c *Client) SendCustomMessage(botToken string, receiverID int64, message string) error {
-	log.Println("SendCustomMessage is called")
-	payload := sendMessagePayload{
-		ChatID: receiverID,
-		Text:   message,
-	}
-	data, err := json.Marshal(payload)
+	log.Println("Request body: ", string(data))
 
 	if err != nil {
 		return err

--- a/application/main.go
+++ b/application/main.go
@@ -6,6 +6,7 @@ import (
 	"dv/services"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"gorm.io/driver/postgres"
@@ -24,16 +25,21 @@ func main() {
 		),
 		PreferSimpleProtocol: true,
 	}), &gorm.Config{})
-
 	if err != nil {
 		panic(err)
 	}
+
 	err = db.AutoMigrate(&models.Message{}, &models.MessageHashtag{})
 	if err != nil {
 		panic(err)
 	}
 
-	messageService := services.NewMessage(db, os.Getenv("BOT_TOKEN"), os.Getenv("BOT_NAME"))
+	chatID, err := strconv.ParseInt(os.Getenv("GROUP_CHAT_ID"), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	messageService := services.NewMessage(db, os.Getenv("BOT_TOKEN"), os.Getenv("BOT_NAME"), chatID)
 	eventHandler := handler.NewEventHandler(messageService)
 	lambda.Start(eventHandler.HandleRequest)
 }

--- a/main.go
+++ b/main.go
@@ -4,17 +4,15 @@ import (
 	"dv/models"
 	"dv/services"
 	"fmt"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 	"log"
 	"net/http"
 	"os"
-	"time"
-
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
+	"strconv"
 )
 
 func main() {
-	time.Sleep(5 * time.Second)
 	db, err := gorm.Open(postgres.New(postgres.Config{
 		DSN: fmt.Sprintf(
 			"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable TimeZone=UTC",
@@ -26,16 +24,21 @@ func main() {
 		),
 		PreferSimpleProtocol: true,
 	}), &gorm.Config{})
-
 	if err != nil {
 		panic(err)
 	}
+
 	err = db.AutoMigrate(&models.Message{}, &models.MessageHashtag{})
 	if err != nil {
 		panic(err)
 	}
 
-	messageService := services.NewMessage(db, os.Getenv("BOT_TOKEN"))
+	chatID, err := strconv.ParseInt(os.Getenv("GROUP_CHAT_ID"), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+
+	messageService := services.NewMessage(db, os.Getenv("BOT_TOKEN"), os.Getenv("BOT_NAME"), chatID)
 
 	log.Println("starting http service @ :8080")
 	http.HandleFunc("/incoming_message", messageService.IncomingMessageHTTPHandler())

--- a/models/message.go
+++ b/models/message.go
@@ -1,20 +1,16 @@
 package models
 
 type WebhookRequest struct {
-	UpdateID int64          `json:"update_id"`
-	Message  WebhookMessage `json:"message"`
+	UpdateID      int64           `json:"update_id"`
+	Message       *WebhookMessage `json:"message"`
+	InlineQuery   *InlineQuery    `json:"inline_query"`
+	CallbackQuery *CallbackQuery  `json:"callback_query"`
 }
 
 type WebhookMessage struct {
-	MessageId int64 `json:"message_id"`
-	From      struct {
-		ID        int64  `json:"id"`
-		IsBot     bool   `json:"is_bot"`
-		FirstName string `json:"first_name"`
-		LastName  string `json:"last_name"`
-		Username  string `json:"username"`
-	} `json:"from"`
-	Chat struct {
+	MessageId int64  `json:"message_id"`
+	From      Sender `json:"from"`
+	Chat      struct {
 		ID    int64  `json:"id"`
 		Title string `json:"title"`
 		Type  string `json:"type"`
@@ -26,6 +22,29 @@ type WebhookMessage struct {
 		Length int    `json:"length"`
 		Type   string `json:"type"`
 	} `json:"entities"`
+}
+
+type Sender struct {
+	ID           int64  `json:"id"`
+	IsBot        bool   `json:"is_bot"`
+	FirstName    string `json:"first_name"`
+	LastName     string `json:"last_name"`
+	Username     string `json:"username"`
+	LanguageCode string `json:"language_code"`
+}
+
+type InlineQuery struct {
+	From     Sender `json:"from"`
+	ChatType string `json:"chat_type"`
+	Query    string `json:"query"`
+	Offset   string `json:"offset"`
+}
+
+type CallbackQuery struct {
+	Id      string         `json:"id"`
+	From    Sender         `json:"from"`
+	Message WebhookMessage `json:"message"`
+	Data    string         `json:"data"`
 }
 
 type Message struct {

--- a/scripts/run_with_env.sh
+++ b/scripts/run_with_env.sh
@@ -1,0 +1,8 @@
+ENV_FILE="$1"
+CMD=${@:2}
+
+set -o allexport
+source $ENV_FILE
+set +o allexport
+
+$CMD

--- a/scripts/set_webhook.sh
+++ b/scripts/set_webhook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+BOT_TOKEN="$1"
+WEBHOOK_URL="$2"
+
+curl -v -XGET "https://api.telegram.org/bot${BOT_TOKEN}/setWebhook?url=${WEBHOOK_URL}"


### PR DESCRIPTION
Adds inline buttons in direct messages.

Example interaction with a bot with inline messages enabled:
![image](https://user-images.githubusercontent.com/1951244/161637437-93fc7c84-34e3-46b0-b41b-adbf66f87b27.png)

In this PR:

- Info about location displayed by one message
- There are Newer/Older inline buttons next to the message
- Older updates about locations are sent when you press "Older"
- Newer updates about location are sent when you press "Newer"(doesn't work well when it comes to the newest message)
- Show "Newer" button only when newer messages are available
- Show "Older" button only when older messages are available
- Types for the inline mode(`InlineQuery`)

In follow up PRs:

- Update message in when user clicks Older/Newer instead of sending a new message every time
- Bot's inline mode